### PR TITLE
Fix ReadTheDocs build error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ tests =
     flake8-import-order
 
 docs =
-    sphinx >=3, <4
+    sphinx >=3, <5
     sphinx-copybutton<1
     myst-parser<1
     furo


### PR DESCRIPTION
<!-- To get a coverage badge: change `$your_source_branch_name$` in the URL below to
the name of your source branch. `target branch` <- merge - `source branch`.
The badge will show the coverage after the first CI run has been completed.
If you do not want to display the coverage, just remove the line below. -->
![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rozsasarpi/da9e3419b54a0daf6fe07b934f37f837/raw/zandbak_docs_fix_coverage.json)
